### PR TITLE
Model acquisition support added.  Generates PCD files. 

### DIFF
--- a/packages/model_acquisition/CMakeLists.txt
+++ b/packages/model_acquisition/CMakeLists.txt
@@ -1,62 +1,73 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(model_acquisition)
 
+find_package(cmake_modules REQUIRED)
+find_package(Eigen REQUIRED)
+find_package(actionlib REQUIRED)
+find_package(Boost REQUIRED COMPONENTS system)
+find_package(PCL 1.7 REQUIRED)
+
 find_package(catkin REQUIRED COMPONENTS
   roscpp
+  sensor_msgs
+  baxter_core_msgs
+  angles
+  baxter_traj_streamer
+  pcl_ros
+  pcl_conversions
+  tf
+  tf2
+  message_generation
 )
 
-## System dependencies are found with CMake's conventions
+link_directories(${PCL_LIBRARY_DIRS})
+
+add_service_files(
+  FILES
+  scan_pose.srv
+  acquire.srv
+)
+
+generate_messages(
+  DEPENDENCIES
+  std_msgs
+)
+
 find_package(Boost REQUIRED COMPONENTS system)
 
-## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
-
-## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Service1.srv
-#   Service2.srv
-# )
-
-## Generate actions in the 'action' folder
-# add_action_files(
-#   FILES
-#   Action1.action
-#   Action2.action
-# )
-
-## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   std_msgs  # Or other packages containing msgs
-# )
-
 catkin_package(
-#  INCLUDE_DIRS include
+  INCLUDE_DIRS include
 #  LIBRARIES model_acquisition
 #  CATKIN_DEPENDS roscpp
 #  DEPENDS system_lib
+  CATKIN_DEPENDS roscpp std_msgs sensor_msgs baxter_core_msgs trajectory_msgs cwru_joint_space_planner baxter_kinematics cwru_srv actionlib_msgs 
+  DEPENDS eigen system_lib actionlib
 )
+
+
 
 include_directories(include)
 include_directories(
   ${catkin_INCLUDE_DIRS}
+  ${PROJECT_NAME}/include
+  ${Eigen_INCLUDE_DIRS}
+  ${PCL_INCLUDE_DIRS}
 )
 
-# add_dependencies(model_acquisition ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+add_definitions(${EIGEN_DEFINITIONS})
+add_definitions(${PCL_DEFINITIONS})
+
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
 
 ## Declare a C++ executable
-# add_executable(model_acquisition_node src/model_acquisition_node.cpp)
 
-## Add cmake target dependencies of the executable
-## same as for the library above
-# add_dependencies(model_acquisition_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+add_executable(model_acquisition src/model_acquisition.cpp
+  src/baxter_interface.cpp
+  src/kinect2_interface.cpp)
 
-## Specify libraries to link a library or executable target against
-# target_link_libraries(model_acquisition_node
-#   ${catkin_LIBRARIES}
-# )
+add_dependencies(model_acquisition baxter_core_msgs baxter_traj_streamer)
+
+target_link_libraries(model_acquisition
+  ${catkin_LIBRARIES}
+  ${PCL_LIBRARIES}
+)

--- a/packages/model_acquisition/README.md
+++ b/packages/model_acquisition/README.md
@@ -2,3 +2,15 @@
 This package will contain software to perform model acquisition by moving a robot's wrist joint in front of a point cloud acquiring sensor, placing an object on a platform attached to the joint, then performing incremental scans.
 
 Currently, only the Baxter robot by Rethink Robotics is supported.
+
+### Usage
+These two nodes must run in order to use the ROS service calls:
+ - `roslaunch model_acquisition kinect.launch`
+ - `roslaunch model_acquisition acquire.launch`
+
+To use the ROS services manually testing:
+ - `rosservice call /go_to_scan_pose "request: false"`
+ - `rosservice call /acquire_model "model_name: 'model_name'"`
+
+PCDs are saved in `~/<ros_ws>/devel/lib/model_acquisition`.
+I'll probably need to write another node that watches for and reorganizes them.

--- a/packages/model_acquisition/config/settings.yaml
+++ b/packages/model_acquisition/config/settings.yaml
@@ -4,4 +4,15 @@ robot: baxter
 scanner: kinect2
 
 # Acquisition settings
-increment_degrees: 10.0
+increment_degrees: 20.0
+
+scan_topic: /kinect2/sd/points
+
+# Scan pose
+scan_left_e0: -1.22143
+scan_left_e1: 1.11635
+scan_left_s0: -0.446772
+scan_left_s1: 0.735544
+scan_left_w0: -1.00284
+scan_left_w1: 2.09388
+scan_left_w2: 0.0

--- a/packages/model_acquisition/include/model_acquisition/abstract_robot.h
+++ b/packages/model_acquisition/include/model_acquisition/abstract_robot.h
@@ -1,0 +1,18 @@
+/*
+ * abstract_robot
+ *
+ * Copyright (c) 2015, Luc Bettaieb
+ * BSD Licensed
+ *
+ */
+
+#ifndef ABSTRACT_ROBOT_H
+#define ABSTRACT_ROBOT_H
+
+// Class is to be filled in later when functionality is tested on other robots.
+
+class AbstractRobot
+{
+};
+
+#endif  // ABSTRACT_ROBOT_H

--- a/packages/model_acquisition/include/model_acquisition/baxter_interface.h
+++ b/packages/model_acquisition/include/model_acquisition/baxter_interface.h
@@ -9,18 +9,42 @@
 #ifndef BAXTER_INTERFACE_H
 #define BAXTER_INTERFACE_H
 
-class BaxterInterface
+#include "model_acquisition/abstract_robot.h"
+
+#include <baxter_core_msgs/JointCommand.h>
+#include <sensor_msgs/JointState.h>
+#include <ros/ros.h>
+
+#include <actionlib/client/simple_action_client.h>
+#include <actionlib/client/terminal_state.h>
+#include <baxter_traj_streamer/baxter_traj_streamer.h>
+
+#include <baxter_traj_streamer/trajAction.h>
+
+#define VECTOR_DIM 7  // e.g., a 7-dof vector
+
+class BaxterInterface : public AbstractRobot
 {
 public:
-	BaxterInterface();
-	virtual ~BaxterInterface();
+  BaxterInterface(ros::NodeHandle &nh);
+  virtual ~BaxterInterface();
 
 private:
-	virtual bool setJointToAngle(int joint, double angle);
+  ros::NodeHandle nh_;
+  // Vectorq7x1 scan_pose;
+
+  virtual void updateLeftJointAngles(const sensor_msgs::JointState& jointstate);
+
+  virtual void doneCb(const actionlib::SimpleClientGoalState& state,
+                      const baxter_traj_streamer::trajResultConstPtr& result);
 
 public:
-	virtual bool incrementScanAngle();
-	virtual bool goToScanPose();
+
+  virtual Vectorq7x1 getLeftArmPose();
+
+  virtual bool goToPose(Vectorq7x1 pose, int lr);
+
+  virtual bool setJointToAngle(int joint, double angle);
 };
 
-#endif // BAXTER_INTERFACE_H
+#endif  // BAXTER_INTERFACE_H

--- a/packages/model_acquisition/include/model_acquisition/kinect2_interface.h
+++ b/packages/model_acquisition/include/model_acquisition/kinect2_interface.h
@@ -1,0 +1,50 @@
+/*
+ * kinect2_interface
+ *
+ * Copyright (c) 2015, Luc Bettaieb
+ * BSD Licensed
+ *
+ */
+
+#ifndef KINECT2_INTERFACE_H
+#define KINECT2_INTERFACE_H
+
+#include <ros/ros.h>
+
+#include <sensor_msgs/PointCloud2.h>
+#include <geometry_msgs/PointStamped.h>
+#include <pcl/io/pcd_io.h>
+#include <pcl/point_types.h>
+#include <pcl/point_cloud.h>
+#include <pcl_ros/point_cloud.h>
+#include <pcl/ros/conversions.h>
+#include <pcl/features/normal_3d.h>
+
+#include <Eigen/Eigen>
+#include <Eigen/Dense>
+
+#include <geometry_msgs/TransformStamped.h>
+
+#include <pcl_ros/transforms.h>
+#include <pcl/filters/extract_indices.h>
+#include <pcl-1.7/pcl/impl/point_types.hpp>
+
+#include <string>
+
+class Kinect2Interface
+{
+public:
+  Kinect2Interface(ros::NodeHandle &nh);
+  virtual ~Kinect2Interface();
+
+  void snapshot(std::string obj_name);
+
+private:
+  ros::NodeHandle nh_;
+
+  pcl::PointCloud<pcl::PointXYZRGB>::Ptr p_pclKinect;
+
+  void kinectCB(const sensor_msgs::PointCloud2ConstPtr &cloud);
+};
+
+#endif  // KINECT2_INTERFACE_H

--- a/packages/model_acquisition/include/model_acquisition/model_acquisition.h
+++ b/packages/model_acquisition/include/model_acquisition/model_acquisition.h
@@ -1,0 +1,25 @@
+/* 
+ * baxter_interface
+ * 
+ * Copyright (c) 2015, Luc Bettaieb
+ * BSD Licensed
+ * 
+ */
+
+#ifndef MODEL_ACQUISITION_H
+#define MODEL_ACQUISITION_H
+
+#include <ros/ros.h>
+#include <angles/angles.h>
+
+#include "model_acquisition/baxter_interface.h"
+#include "model_acquisition/kinect2_interface.h"
+
+#include "model_acquisition/scan_pose.h"
+#include "model_acquisition/acquire.h"
+
+bool goToScanPose(model_acquisition::scan_pose::Request &request, model_acquisition::scan_pose::Response &response);
+
+bool acquireModel(model_acquisition::acquire::Request &request, model_acquisition::acquire::Response &response);
+
+#endif  // MODEL_ACQUISITION_H

--- a/packages/model_acquisition/launch/acquire.launch
+++ b/packages/model_acquisition/launch/acquire.launch
@@ -1,0 +1,9 @@
+<launch>
+
+  <node pkg="baxter_traj_streamer" type="traj_interpolator_as" name="traj_interpolator_as" />
+
+  <node pkg="model_acquisition" type="model_acquisition" name="model_acquisition" output="screen" cwd="node">
+    <rosparam command="load" file="$(find model_acquisition)/config/settings.yaml" />
+  </node>
+
+</launch>

--- a/packages/model_acquisition/launch/kinect.launch
+++ b/packages/model_acquisition/launch/kinect.launch
@@ -1,0 +1,7 @@
+<launch>
+	<include file="$(find camera_calibration)/launch/kinect2_transform.launch" />
+
+	<remap from="kinect2/qhd/points" to="kinect/depth/points" />
+	
+	<include file="$(find kinect2_bridge)/launch/kinect2_bridge.launch"/>
+</launch>

--- a/packages/model_acquisition/package.xml
+++ b/packages/model_acquisition/package.xml
@@ -9,16 +9,40 @@
   <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
   <maintainer email="luc.bettaieb@gmail.com">Luc Bettaieb</maintainer>
 
-
   <!-- One license tag required, multiple allowed, one license per tag -->
   <!-- Commonly used license strings: -->
   <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>roscpp</build_depend>
-  <run_depend>roscpp</run_depend>
 
+  <build_depend>roscpp</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>baxter_core_msgs</build_depend>
+  <build_depend>angles</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>trajectory_msgs</build_depend>
+  <build_depend>cwru_joint_space_planner</build_depend>
+  <build_depend>baxter_kinematics</build_depend>
+  <build_depend>cwru_srv</build_depend>
+  <build_depend>actionlib_msgs</build_depend>
+  <build_depend>actionlib</build_depend>
+  <build_depend>baxter_traj_streamer</build_depend>
+  <build_depend>message_generation</build_depend>
+
+  <run_depend>roscpp</run_depend>
+  <run_depend>sensor_msgs</run_depend>
+  <run_depend>baxter_core_msgs</run_depend>
+  <run_depend>angles</run_depend>
+  <run_depend>std_msgs</run_depend>
+  <run_depend>trajectory_msgs</run_depend>
+  <run_depend>cwru_joint_space_planner</run_depend>
+  <run_depend>baxter_kinematics</run_depend>
+  <run_depend>cwru_srv</run_depend>
+  <run_depend>actionlib_msgs</run_depend>
+  <run_depend>actionlib</run_depend>
+  <run_depend>baxter_traj_streamer</run_depend>
+  <run_depend>message_runtime</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/packages/model_acquisition/src/baxter_interface.cpp
+++ b/packages/model_acquisition/src/baxter_interface.cpp
@@ -3,33 +3,162 @@
  * 
  * Copyright (c) 2015, Luc Bettaieb
  * BSD Licensed
- * 
  */
 
-#include <baxter_interface.h>
-#include <ros/ros.h>
+#include "model_acquisition/baxter_interface.h"
 
-BaxterInterface::BaxterInterface()
+#include <vector>
+#include <control_msgs/FollowJointTrajectoryAction.h>
+
+ros::Publisher g_LeftJointPublisher;
+ros::Subscriber g_LeftJointListener;
+
+baxter_core_msgs::JointCommand left_cmd;
+double leftJointAngles [7];
+
+BaxterInterface::BaxterInterface(ros::NodeHandle &nh)
 {
-	// load in increment angle from parameter server
-	// make sure its divisible by 360, if not, set to closest angle that is divisible by 360
+  // load in increment angle from parameter server
+  // make sure its divisible by 360, if not, set to closest angle that is divisible by 360
+  nh_ = nh;
+
+  left_cmd.mode = baxter_core_msgs::JointCommand::RAW_POSITION_MODE;
+  left_cmd.names.push_back("left_s0");
+  left_cmd.names.push_back("left_s1");
+  left_cmd.names.push_back("left_e0");
+  left_cmd.names.push_back("left_e1");
+  left_cmd.names.push_back("left_w0");
+  left_cmd.names.push_back("left_w1");
+  left_cmd.names.push_back("left_w2");
+
+  left_cmd.command.resize(7, 0.0);
+
+  g_LeftJointPublisher = nh_.advertise<baxter_core_msgs::JointCommand>("/robot/limb/left/joint_command", 1);
+  g_LeftJointListener = nh_.subscribe("/robot/joint_states", 3, &BaxterInterface::updateLeftJointAngles, this);
 }
+
 BaxterInterface::~BaxterInterface()
 {
+}
 
+void BaxterInterface::doneCb(const actionlib::SimpleClientGoalState& state,
+                             const baxter_traj_streamer::trajResultConstPtr& result)
+{
+  ROS_INFO(" doneCb: server responded with state [%s]", state.toString().c_str());
+  ROS_INFO("got return val = %d; traj_id = %d", result->return_val, result->traj_id);
+}
+
+Vectorq7x1 BaxterInterface::getLeftArmPose()
+{
+  Vectorq7x1 pose;
+
+  pose(2, 0) = leftJointAngles[0];
+  pose(3, 0) = leftJointAngles[1];
+  pose(0, 0) = leftJointAngles[2];
+  pose(1, 0) = leftJointAngles[3];
+  pose(4, 0) = leftJointAngles[4];
+  pose(5, 0) = leftJointAngles[5];
+  pose(6, 0) = leftJointAngles[6];
+
+  return pose;
+}
+
+
+void BaxterInterface::updateLeftJointAngles(const sensor_msgs::JointState& jointstate)
+{
+  for (uint i = 0; i < 7; i++)
+  {
+    leftJointAngles[i] = jointstate.position.at(i+2);
+  }
 }
 
 bool BaxterInterface::setJointToAngle(int joint, double angle)
 {
+  for (uint i = 0; i < 7; i++)
+  {
+    left_cmd.command[i] = leftJointAngles[i];
+  }
 
+  // left_cmd.command.at(joint) = angle;
+  g_LeftJointPublisher.publish(left_cmd);
 }
 
-bool BaxterInterface::goToScanPose()
+bool BaxterInterface::goToPose(Vectorq7x1 pose, int lr)
 {
+  uint g_count = 0;
+  uint ans;
+  Eigen::VectorXd q_in_vecxd;
 
-}
+  Vectorq7x1 q_vec_left_arm;
 
-bool BaxterInterface::incrementScanAngle()
-{
+  std::vector<Eigen::VectorXd> des_path;
 
+  trajectory_msgs::JointTrajectory des_trajectory;
+
+  ROS_DEBUG("Instantiating a traj streamer");
+  Baxter_traj_streamer ts(&nh_);
+
+  ROS_DEBUG("Warming up callbacks");  // Is this necessary?  Test with and without it.
+  for (uint i = 0; i < 100; i++)
+  {
+    ros::spinOnce();
+    ros::Duration(0.01).sleep();
+  }
+
+  ROS_DEBUG("Getting current pose.");
+
+  for (uint i = 0; i < 7; i++)
+  {
+    q_vec_left_arm = getLeftArmPose();  // NEED TO MAKE WORK FOR RIGHT ARM
+  }
+
+  q_in_vecxd = q_vec_left_arm;
+  des_path.push_back(q_in_vecxd);
+
+  q_in_vecxd = pose;
+  des_path.push_back(q_in_vecxd);
+
+  ts.stuff_trajectory(des_path, des_trajectory);
+
+  baxter_traj_streamer::trajGoal goal;
+  goal.trajectory = des_trajectory;
+
+  actionlib::SimpleActionClient<baxter_traj_streamer::trajAction> action_client("trajActionServer", true);
+
+  ROS_DEBUG("Waiting for server: ");
+
+  if (!action_client.waitForServer(ros::Duration(5.0)))
+  {
+    ROS_WARN("Could not connect to server.");
+    return false;
+  }
+
+  ROS_DEBUG("Connected to action server");
+
+  g_count++;
+  goal.traj_id = g_count;
+
+  if (lr != 1 && lr != 0)
+  {
+    ROS_WARN("left or right arm not selected.  halting.");
+    return false;
+  }
+
+  goal.left_or_right = lr;
+
+  ROS_DEBUG("Sending traj_id %d", g_count);
+
+  action_client.sendGoal(goal, boost::bind(&BaxterInterface::doneCb, this, _1, _2));
+
+  if (!action_client.waitForResult(ros::Duration(5.0)))
+  {
+    ROS_WARN("Giving up waiting on result for traj_id: %d", g_count);
+    return false;
+  }
+  else
+  {
+    ROS_DEBUG("Finished before timeout!");
+  }
+
+  return true;
 }

--- a/packages/model_acquisition/src/kinect2_interface.cpp
+++ b/packages/model_acquisition/src/kinect2_interface.cpp
@@ -1,0 +1,61 @@
+/*
+ * kinect2_interface
+ *
+ * Copyright (c) 2015, Luc Bettaieb
+ * BSD Licensed
+ */
+
+#include "model_acquisition/kinect2_interface.h"
+
+ros::Subscriber g_getPointCloud;
+
+std::string g_prev_obj_name;
+std::string g_scan_topic;
+
+std::string home = "~/.ros";
+
+// pcl::PointCloud<pcl::PointXYZ>::Ptr p_pclKinect(new pcl::PointCloud<pcl::PointXYZ>);
+
+uint g_snapshot_number;
+
+Kinect2Interface::Kinect2Interface(ros::NodeHandle &nh):p_pclKinect(new pcl::PointCloud<pcl::PointXYZRGB>)
+{
+  nh_ = nh;
+  g_snapshot_number = 0;
+  // get topic for kinect2 PointCloud2
+  // get PCD directory from config
+
+  if (!nh.getParam("model_acquisition/scan_topic", g_scan_topic))
+    g_scan_topic = "/kinect2/qhd/points";  // Default behavior
+
+  g_getPointCloud = nh.subscribe<sensor_msgs::PointCloud2> (g_scan_topic, 1, &Kinect2Interface::kinectCB, this);
+}
+
+Kinect2Interface::~Kinect2Interface()
+{
+  // Do I need to delete things here?
+}
+
+void Kinect2Interface::kinectCB(const sensor_msgs::PointCloud2ConstPtr &cloud)
+{
+  pcl::fromROSMsg(*cloud, *p_pclKinect);
+  // ROS_INFO("kinectCB %d * %d points", (int) g_pclKinect->width, (int) g_pclKinect->height);
+}
+
+void Kinect2Interface::snapshot(std::string obj_name)
+{
+  ros::spinOnce();
+  std::string file_name;
+
+  file_name = obj_name + std::to_string(g_snapshot_number);
+
+  pcl::io::savePCDFileASCII(file_name + ".pcd", *p_pclKinect);
+  
+  if (g_snapshot_number > 0 && obj_name.compare(g_prev_obj_name) != 0)
+    g_snapshot_number = 0;
+  else
+  {
+    g_snapshot_number++;
+    g_prev_obj_name = obj_name;
+  }
+}

--- a/packages/model_acquisition/src/model_acquisition.cpp
+++ b/packages/model_acquisition/src/model_acquisition.cpp
@@ -1,0 +1,107 @@
+/*
+ * model_acquisition
+ *
+ * Copyright (c) 2015, Luc Bettaieb
+ * BSD Licensed
+ *
+ */
+
+#include "model_acquisition/model_acquisition.h"
+
+std::string g_robot;
+std::string g_scanner;
+
+double g_increment_degrees;
+double g_increment_radians;
+
+std::vector<double> g_scan_pose(7);
+Vectorq7x1 g_vec_scan_pose;
+
+BaxterInterface* baxter;
+Kinect2Interface* kinect;
+
+bool goToScanPose(model_acquisition::scan_pose::Request &request,
+                  model_acquisition::scan_pose::Response &response)
+{
+  ROS_INFO("Set Scan Pose!");
+  baxter->goToPose(g_vec_scan_pose, 1);
+
+  return true;
+}
+
+bool acquireModel(model_acquisition::acquire::Request &request,
+                  model_acquisition::acquire::Response &response)
+{
+  ROS_INFO("Acquire Model!");
+
+  for (double d = -M_PI; d < M_PI; d += g_increment_radians)
+  {
+    g_vec_scan_pose(6, 0) = d;
+    baxter->goToPose(g_vec_scan_pose, 1);
+
+    ROS_INFO("snapshot");
+    
+    kinect->snapshot(request.model_name);
+    ros::spinOnce();  // This might not be necessary since it's inside kinect2Interface::snapshot already
+  }
+
+  return true;
+}
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "model_acquisition");
+  ros::NodeHandle nh;
+
+  if (!nh.getParam("model_acquisition/robot", g_robot))
+    g_robot = "robot_undefined";  // Undefined robot
+
+  if (!nh.getParam("model_acquisition/scanner", g_scanner))
+    g_scanner = "scanner_undefined";  // Undefined scanner
+
+  if (!nh.getParam("model_acquisition/increment_degrees", g_increment_degrees))
+    g_increment_degrees = 10.0;  // Default value
+
+  if (!nh.getParam("model_acquisition/scan_left_e0", g_scan_pose[0]))
+    g_scan_pose[0] = -1.22143;
+
+  if (!nh.getParam("model_acquisition/scan_left_e1", g_scan_pose[1]))
+    g_scan_pose[1] = 1.11635;
+
+  if (!nh.getParam("model_acquisition/scan_left_s0", g_scan_pose[2]))
+    g_scan_pose[2] = -0.446772;
+
+  if (!nh.getParam("model_acquisition/scan_left_s1", g_scan_pose[3]))
+    g_scan_pose[3] = 0.735544;
+
+  if (!nh.getParam("model_acquisition/scan_left_w0", g_scan_pose[4]))
+    g_scan_pose[4] = -1.00284;
+
+  if (!nh.getParam("model_acquisition/scan_left_w1", g_scan_pose[5]))
+    g_scan_pose[5] = 2.09388;
+
+  if (!nh.getParam("model_acquisition/scan_left_w2", g_scan_pose[6]))
+    g_scan_pose[6] = 0.0;
+
+  g_increment_radians = angles::from_degrees(g_increment_degrees);
+
+  baxter = new BaxterInterface(nh);
+  kinect = new Kinect2Interface(nh);
+  
+  // The line order is the order in which looking at the ROS topic gives the joint angles.
+  // 'left_e0', 'left_e1', 'left_s0', 'left_s1', 'left_w0', 'left_w1', 'left_w2'
+  // There is a mismatch in how WSN's code interprets the joint angles vs. how rethink does.
+
+  g_vec_scan_pose(2, 0) = g_scan_pose[0];
+  g_vec_scan_pose(3, 0) = g_scan_pose[1];
+  g_vec_scan_pose(0, 0) = g_scan_pose[2];
+  g_vec_scan_pose(1, 0) = g_scan_pose[3];
+  g_vec_scan_pose(4, 0) = g_scan_pose[4];
+  g_vec_scan_pose(5, 0) = g_scan_pose[5];
+  g_vec_scan_pose(6, 0) = g_scan_pose[6];
+
+  ros::ServiceServer goToScan = nh.advertiseService("go_to_scan_pose", goToScanPose);
+  ros::ServiceServer acquire = nh.advertiseService("acquire_model", acquireModel);
+
+  ros::spin();
+}

--- a/packages/model_acquisition/srv/acquire.srv
+++ b/packages/model_acquisition/srv/acquire.srv
@@ -1,0 +1,5 @@
+# A ROS service to request that a robot may acquire a model
+
+string model_name
+---
+bool done

--- a/packages/model_acquisition/srv/scan_pose.srv
+++ b/packages/model_acquisition/srv/scan_pose.srv
@@ -1,0 +1,4 @@
+# A ROS service to request that a robot may assume a scanning pose
+bool request
+---
+bool done

--- a/scripts/clone_repos.sh
+++ b/scripts/clone_repos.sh
@@ -15,8 +15,7 @@ then
 
 	# set up cwru things
 	#you might want to change this to a fork?
-  (cd ~/$WS_NAME/src/cwru && git clone https://github.com/cwru-robotics/cwru_baxter.git)
-
+    (cd ~/$WS_NAME/src/cwru && git clone https://github.com/cwru-robotics/cwru_baxter.git)
 
 	(cd ~/$WS_NAME/src/cwru && git clone https://github.com/cwru-robotics/cwru_msgs.git)
 	(cd ~/$WS_NAME/src/cwru && git clone https://github.com/catkin/catkin_simple.git)

--- a/scripts/install_freenect.sh
+++ b/scripts/install_freenect.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Luc Bettaieb 2015
+echo "installing libfreenect2"
+
+sudo apt-get install -y build-essential libturbojpeg libtool autoconf libudev-dev cmake mesa-common-dev freeglut3-dev libxrandr-dev doxygen libxi-dev libopencv-dev
+sudo ln -s /usr/lib/x86_64-linux-gnu/libturbojpeg.so.0 /usr/lib/x86_64-linux-gnu/libturbojpeg.so
+
+DIRECTORY=`locate libfreenect2 | sed -n '1 p'`
+
+echo $DIRECTORY
+
+if [$DIRECTORY != ""]; then
+
+	# check to see if directory is a directory 
+	# else throw an error
+
+	(cd $DIRECTORY/depends && ./install_ubuntu.sh)
+
+	(cd $DIRECTORY/depends && sudo dpkg -i libglfw3*_3.0.4-1_*.deb)
+
+	(cd $DIRECTORY && mkdir build)
+	(cd $DIRECTORY/build && cmake ../examples/protonect/ -DENABLE_CXX11=ON)
+	(cd $DIRECTORY/build && make && sudo make install)
+else
+	echo "need to clone libfreenect2 somewhere first!!"
+
+fi


### PR DESCRIPTION
Launch kinect.launch to start kinect2 topic and transform.  Launch acquire.launch to start ROS services.

Call /go_to_scan_pose with any input args to make robot assume scan pose
Call /acquire_model with the name of the model as an input arg to generate pcd files
currently dumps all pcd files to ~/ws/devel/lib/model_acquisition
